### PR TITLE
Fix xml not formatted correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ FreshBooks.prototype._get = function(xml, fn) {
     , path: url.parse(this.url).path
     , method: 'POST'
     , headers: {
-      'Content-Length': string.length
+      'Content-Length': Buffer.byteLength(string, 'utf8')
       , 'Authorization': 'Basic ' + new Buffer(this.token + ':X').toString('base64')
     }
   };

--- a/test/Invoice.js
+++ b/test/Invoice.js
@@ -32,6 +32,19 @@ describe('Invoice', function() {
       });
     });
   });
+  
+  describe("update()", function() {
+    it("should update an invoice with 2 bytes (or more) chars", function(done) {
+      var invoiceId = invoice.invoice_id;
+
+      var updatingInvoice = new freshbooks.Invoice();
+      updatingInvoice.invoice_id = invoiceId;
+      updatingInvoice.notes = "!?%€$ éèîàü  ﷰ Подтверждение 賬戶驗證";
+      updatingInvoice.update(function(err, invoice) {
+        done(err);
+      });
+    });
+  });
 
   describe("get()", function() {
     it("should get an invoice", function(done) {


### PR DESCRIPTION
Fix freshbook webservice response "_Your XML is not formatted correctly_" that happened when the posted XML contains characters that are more than 1 byte size encoded in UTF-8, such as french accents for example éàù, or others characters like € (3 bytes) and way more others.

The problem comes from the 'Content-Length': string.length in _index.js_, this only worked if the xml contains 1 byte characters encoded. If not, the Content-Length sent is too short and the xml is cutted before the end.

I fixed this using Buffer.byteLength: Returns the actual byte length of a string.
(https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)
